### PR TITLE
fix: use array form of CMD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ADD config.ru /sidekiq/
 
 EXPOSE 3030
 ENTRYPOINT []
-CMD rackup config.ru -o 0.0.0.0 -p 3030 -q
+CMD ["rackup", "config.ru", "-o", "0.0.0.0", "-p", "3030", "-q"]


### PR DESCRIPTION
Avoids this warning from `docker build`:

```
JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals
```